### PR TITLE
Fix jericho grounding accuracy

### DIFF
--- a/agentboard/environment/jericho_env.py
+++ b/agentboard/environment/jericho_env.py
@@ -180,6 +180,20 @@ class Jericho(BaseEnvironment):
             return False
         
     def step(self, action):
+        invalid_action_responses = [
+            "[!",
+            "That's not a verb I",
+            "I didn't understand that sentence",
+            "I don't know the word",
+            "\"Huh?\" The wolf raises an eyebrow.",
+            "I haven't the slightest idea what you're referring to",
+            "Perhaps you would care to rephrase that",
+            "Whatever are you talking about",
+            "That's not a trick you know",
+            "I beg your pardon?",
+            "There was no verb in that sentence!",
+        ]
+
         if self.validate_check_valid_actions(action): # add a special action to check valid actions
             obs = "You can take the following actions: " + ", ".join(self._get_action_space())
             self.update_info(action, obs) 
@@ -189,7 +203,7 @@ class Jericho(BaseEnvironment):
             observation, reward, done, info = self.env.step(action)
             observation = self.clean_up_text(observation)
             self.update(action, observation, reward, done, info)
-            if '[!' in observation:
+            if any(s in observation for s in invalid_action_responses):
                 self.infos["action_is_valid"] = False
             else:
                 self.infos["action_is_valid"] = True


### PR DESCRIPTION
The jericho environment does not detect invalid actions correctly for any of the games except `905`. This means the reported grounding accuracy is way higher than the actual value.

It looks for `[!` to determine verb errors, but every game handles verb errors differently. Like `acorncourt` says `That's not a verb I recognise.`, or `library` says `I didn't understand that sentence.`, or `zork1` says `I don't know the word X`, or `loose` says `"I haven't the slightest idea what you're referring to," murmurs the egg.` or `"Huh?" The wolf raises an eyebrow.`, or `snacktime` says `That's not a trick you know.`. Partial valid verbs respond with `I only understood you as far as wanting to X`. `I beg your pardon?` if you say nothing.

This PR fixes the issue and reports the actual grounding accuracy in Jericho.