### PR TITLE
Add human and gpt-4o engines

### DIFF
--- a/agentboard/llm/__init__.py
+++ b/agentboard/llm/__init__.py
@@ -4,13 +4,15 @@ from .claude import CLAUDE
 from .vllm import VLLM
 from common.registry import registry
 from .huggingface import HgModels
+from .human import HUMAN
 
 __all__ = [
     "OPENAI_GPT",
     "OPENAI_GPT_AZURE",
     "VLLM",
     "CLAUDE",
-    "HgModels"
+    "HgModels",
+    "HUMAN"
 ]
 
 

--- a/agentboard/llm/human.py
+++ b/agentboard/llm/human.py
@@ -1,0 +1,19 @@
+from common.registry import registry
+
+@registry.register_llm("human")
+class HUMAN:
+    def __init__(self):
+        self.engine = "human"
+        self.context_length = 100000000
+        self.max_tokens = 10000
+
+    def generate(self, system_message, prompt):
+        return True, input("")
+
+    def num_tokens_from_messages(self, messages, model="gpt-3.5-turbo-0613"):
+        """Return the number of tokens used by a list of messages."""
+        return 0
+
+    @classmethod
+    def from_config(cls, config):
+        return cls()

--- a/eval_configs/main_results_all_tasks.yaml
+++ b/eval_configs/main_results_all_tasks.yaml
@@ -13,6 +13,22 @@ agent:
   need_goal: True
 
 llm:
+  human:
+      name: human
+      engine: human
+      context_length: 128000
+      use_parser: False
+  gpt-4o:
+      name: gpt
+      engine: gpt-4o
+      context_length: 128000 # 4096
+      use_azure: False
+      temperature: 0.
+      top_p: 1
+      retry_delays: 20
+      max_retry_iters: 15
+      stop: "\n"
+      use_parser: False
   gpt-3.5-turbo-16k:
       name: gpt
       engine: gpt-3.5-turbo-16k


### PR DESCRIPTION
This PR adds two new LLMs to test with:
- Human: Uses the `input()` keyword to prompt the user to input the action. Useful for testing and debugging.
- GPT-4o: The new model by OpenAI.