### PR TITLE
Fix template of `carry` predicate

### DIFF
--- a/agentboard/environment/pddl_env/pddl_env.py
+++ b/agentboard/environment/pddl_env/pddl_env.py
@@ -332,7 +332,7 @@ predicate_map = {
     "at-robby": "Robby is at {}. ",
     "at": "{} is at {}. ",
     "free": "{} is free. ",
-    "carry": "{} is carrying {}. ",
+    "carry": "{} is carried by {}. ",
     "move": "Move from {} to {}. ",
     "pick": "Pick up {} at {} with arm {}. ",
     # Add more predicate formats here  


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2e7655d3-d57e-446d-bc4a-873d611ae231)


Template of `carry` predicate is generating wrong description.