### PR TITLE
(BUG FIX) ModuleNotFoundError: No module named 'playwright._impl._api_types'

### DIFF
--- a/agentboard/tasks/webbrowse.py
+++ b/agentboard/tasks/webbrowse.py
@@ -10,7 +10,7 @@ from common.registry import registry
 import traceback
 from beartype import beartype
 from beartype.door import is_bearable
-from playwright._impl._api_types import Error, TimeoutError
+from playwright._impl._errors import Error, TimeoutError
 from agents import load_agent
 from agents.vanilla_agent import VanillaAgent
 from llm import load_llm


### PR DESCRIPTION
Fixes `ModuleNotFoundError: No module named 'playwright._impl._api_types'`

playwright-python no longer has a playwright._impl._api_types.py file (https://github.com/microsoft/playwright-python/tree/main/playwright/_impl). The Error and TimeoutError classes can now be found in https://github.com/microsoft/playwright-python/blob/main/playwright/_impl/_errors.py.